### PR TITLE
fix host in request header

### DIFF
--- a/docrepository/addToESindex/indexDocument.js
+++ b/docrepository/addToESindex/indexDocument.js
@@ -15,7 +15,7 @@
 */
 
 const AWS = require('aws-sdk')
-AWS.config.region = process.env.AWS_REGION 
+AWS.config.region = process.env.AWS_REGION
 const type = '_doc'
 
 const indexDocument = async (event) => {
@@ -23,18 +23,18 @@ const indexDocument = async (event) => {
     const endpoint = new AWS.Endpoint(process.env.domain)
     let request = new AWS.HttpRequest(endpoint, process.env.AWS_REGION)
     const document = event.content
-  
+
     request.method = 'PUT'
     request.path += event.index + '/' + type + '/' + event.id
     request.body = JSON.stringify(document)
-    request.headers['host'] = process.env.domain
+    request.headers['host'] = endpoint.host
     request.headers['Content-Type'] = 'application/json';
     request.headers['Content-Length'] = Buffer.byteLength(request.body)
-  
+
     const credentials = new AWS.EnvironmentCredentials('AWS')
     const signer = new AWS.Signers.V4(request, 'es')
     signer.addAuthorization(credentials, new Date())
-  
+
     const client = new AWS.HttpClient()
     client.handleRequest(request, null, function(response) {
       console.log(response.statusCode + ' ' + response.statusMessage)


### PR DESCRIPTION
Following instruction at https://aws.amazon.com/blogs/compute/creating-a-searchable-enterprise-document-repository/, I  deployed the sam template  with the endpoint url of my elastic search instance. 

The last lambda function in the pipeline, AddToESFunction, fails since the host in the request header to the elastic  search  service is set to the full URL , instead of just the domain  name part

The fix is a one line change
