### PR TITLE
Pin deps for DynamoDB Importer

### DIFF
--- a/ddbImporter/dataGenerator/package.json
+++ b/ddbImporter/dataGenerator/package.json
@@ -10,7 +10,7 @@
   "author": "James Beswick, AWS Serverless",
   "license": "MIT-0",
   "dependencies": {
-    "faker": "latest",
-    "fs": "latest"
+    "faker": "5.5.3",
+    "fs": "0.0.1-security"
   }
 }

--- a/ddbImporter/v1/importFunction/package.json
+++ b/ddbImporter/v1/importFunction/package.json
@@ -10,7 +10,7 @@
   "author": "AWS Serverless",
   "license": "MIT-0",
   "dependencies": {
-    "aws-sdk": "latest",
-    "uuid": "latest"
+    "aws-sdk": "^2.1069.0",
+    "uuid": "^8.3.2"
   }
 }

--- a/ddbImporter/v2/addToQueueFunction/package.json
+++ b/ddbImporter/v2/addToQueueFunction/package.json
@@ -10,7 +10,7 @@
   "author": "James Beswick",
   "license": "MIT-0",
   "dependencies": {
-    "aws-sdk": "latest",
-    "uuid": "latest"
+    "aws-sdk": "^2.1069.0",
+    "uuid": "^8.3.2"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
GitHub CVE ID: https://github.com/advisories/GHSA-gh88-3pxp-6fm8 

*Description of changes:*
Pin npm packages in DynamoDB Importer.  Latest release of faker.js ([v6.6.6](https://www.npmjs.com/package/faker/v/6.6.6)) breaks data generator.  Will pin deps for other modules in a separate PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
